### PR TITLE
fix: Monthly page can now handle double digit month nums

### DIFF
--- a/scripts/utils/MonthlyDirectory.js
+++ b/scripts/utils/MonthlyDirectory.js
@@ -41,7 +41,7 @@ class MonthlyDirectory {
   }
 
   createSortableKey(month, year) {
-    return [year, month].join('-');
+    return [year, month < 10 ? `0${month}` : month].join('-');
   }
 
   createSectionIfNotExists(key) {


### PR DESCRIPTION
Monthly page can now handle double digit month nums, fixes #9 